### PR TITLE
Fix brush size crash

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -122,7 +122,7 @@ namespace NDI_Telestrator
 
         public ICommand handleSelectThickness
         {
-            get => new SimpleCommand(o => InkControls.setPenThickness(double.Parse((string)o)));
+            get => new SimpleCommand(o => InkControls.setPenThickness(double.Parse((string)o, System.Globalization.CultureInfo.InvariantCulture)));
         }
 
         #endregion


### PR DESCRIPTION
double.parse() is region dependent by default, so it fails when the local region settings don't have '.' set as decimal separator.

Fixes #11 